### PR TITLE
New version 2.3.0

### DIFF
--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -150,11 +150,10 @@ class PhpEcho
 
     /**
      * Interface ArrayAccess
+     * The returned value is escaped
      *
-     * Return escaped value for
-     *     - scalars
-     *     - array (escape keys and values)
-     *     - stringifyable instance (class implementing __toString() method)
+     * Some types are preserved : true bool, true int, true float, PhpEcho instance, object without __toString()
+     * Otherwise, the value is cast to a string and escaped
      *
      * If object: return the object
      *
@@ -165,10 +164,14 @@ class PhpEcho
     {
         if (isset($this->vars[$offset])) {
             $v = $this->vars[$offset];
-            if (is_object($v) || is_bool($v) || is_int($v) || is_float($v)) {
-                return $v;
-            } elseif (is_array($v) || $this('$is_scalar', $v)) {
+            if (is_string($v) || is_array($v)) {
                 return $this('$hsc', $v);
+            } elseif (is_bool($v) || is_int($v) || is_float($v) || ($v instanceof PhpEcho)) {
+                return $v;
+            } elseif ($this('$is_scalar', $v)) {
+                return $this('$hsc', $v);
+            } else {
+                return $v;
             }
         }
         return null;
@@ -184,7 +187,7 @@ class PhpEcho
         $this->vars[$offset] = $value;
         if ($value instanceof PhpEcho) {
             $this->has_children = true;
-            $value->parent   = $this;
+            $value->parent      = $this;
         }
     }
 

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -53,6 +53,9 @@ if ( ! defined('HELPER_RETURN_ESCAPED_DATA')) {
  * @method string link(array $attributes)   [rel => required, attribute => value]
  * @method string style(array $attributes)  [href => url | code => plain css definition, attribute => value]
  * @method string script(array $attributes) [src => url | code => plain javascript, attribute => value]
+ * @method mixed  keyUp($keys, bool $strict_match)
+ * @method mixed  keyDown($keys)
+ * @method mixed  param($keys)
  */
 class PhpEcho
     implements ArrayAccess
@@ -164,11 +167,7 @@ class PhpEcho
     {
         if (isset($this->vars[$offset])) {
             $v = $this->vars[$offset];
-            if (is_string($v) || is_array($v)) {
-                return $this('$hsc', $v);
-            } elseif (is_bool($v) || is_int($v) || is_float($v) || ($v instanceof PhpEcho)) {
-                return $v;
-            } elseif ($this('$is_scalar', $v)) {
+            if ($this('$to_escape', $v)) {
                 return $this('$hsc', $v);
             } else {
                 return $v;

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -39,23 +39,23 @@ if ( ! defined('HELPER_RETURN_ESCAPED_DATA')) {
  *              OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  *              SOFTWARE.
  *
- *
- * @method mixed  raw(string $key)      Return the raw value from a PhpEcho block
- * @method mixed  hsc($p)               Escape the value in parameter (scalar, array, stringifyable)
- * @method bool   isScalar($p)
+ * PhpEcho HELPERS
+ * @method mixed   raw(string $key)                 Return the raw value from a PhpEcho block
+ * @method bool    isScalar($p)
+ * @method mixed   keyUp($keys, bool $strict_match) Climb the tree of PhpEcho instances while keys match
+ * @method mixed   param($keys)                     Extract a value from the root PhpEcho instance of the tree
+ * @method PhpEcho root()                           Return the root PhpEcho instance of the tree
  *
  * HTML HELPERS
- * @method string attributes(array $p)  Return the values as escaped attributes: attribute="..."
- * @method string selected($p, $ref)    Return " selected " if $p == $ref
- * @method string checked($p, $ref)     Return " checked "  if $p == $ref
- * @method string voidTag(string $tag, array $attributes = [])  Build a <tag>
- * @method string tag(string $tag, array $attributes = [])      Build a <tag></tag>
- * @method string link(array $attributes)   [rel => required, attribute => value]
- * @method string style(array $attributes)  [href => url | code => plain css definition, attribute => value]
- * @method string script(array $attributes) [src => url | code => plain javascript, attribute => value]
- * @method mixed  keyUp($keys, bool $strict_match) Climb the tree of PhpEcho instances while keys match
- * @method mixed  param($keys)              Extract a value from the root PhpEcho instance of the tree
- * @method PhpEcho root()                   Return the root PhpEcho instance of the tree
+ * @method mixed   hsc($p)                          Escape the value in parameter (scalar, array, stringifyable)
+ * @method string  attributes(array $p)             Return the values as escaped attributes: attribute="..."
+ * @method string  selected($p, $ref)               Return " selected " if $p == $ref
+ * @method string  checked($p, $ref)                Return " checked "  if $p == $ref
+ * @method string  voidTag(string $tag, array $attributes = [])  Build a <tag>
+ * @method string  tag(string $tag, array $attributes = [])      Build a <tag></tag>
+ * @method string  link(array $attributes)          [rel => required, attribute => value]
+ * @method string  style(array $attributes)         [href => url | code => plain css definition, attribute => value]
+ * @method string  script(array $attributes)        [src => url | code => plain javascript, attribute => value]
  */
 class PhpEcho
     implements ArrayAccess

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -63,6 +63,10 @@ class PhpEcho
     private static $ALPHANUM = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
     /**
+     * @var array
+     */
+    private static $tokens = [];
+    /**
      * @var string
      */
     private $id = '';
@@ -318,12 +322,17 @@ class PhpEcho
     }
 
     /**
-     * @param int $length
+     * @param int $length   min = 12 chars
      * @return string
      */
     private static function token(int $length = 12): string
     {
-        return substr(str_shuffle(self::$ALPHANUM.mt_rand(100000000, 999999999)), 0, $length);
+        $length = ($length < 12) ? 12 : $length;
+        do {
+            $token = substr(str_shuffle(self::$ALPHANUM.mt_rand(100000000, 999999999)), 0, $length);
+        } while (isset(self::$tokens[$token]));
+        self::$tokens[$token] = true;
+        return $token;
     }
 
     //region MAGIC METHODS

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -310,10 +310,17 @@ class PhpEcho
     public function head(bool $escape): string
     {
         // generate a token that will be replaced after rendering the whole HTML
-        $token = str_shuffle(self::$ALPHANUM).mt_rand(100000000, 999999999);
-        $this->head_token  = $token;
+        $this->head_token  = self::token();
         $this->head_escape = $escape;
-        return $token;
+        return $this->head_token;
+    }
+
+    /**
+     * @return string
+     */
+    private static function token(): string
+    {
+        return str_shuffle(self::$ALPHANUM).mt_rand(100000000, 999999999);
     }
 
     /**

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -108,6 +108,10 @@ class PhpEcho
      * @var PhpEcho
      */
     private $parent;
+    /**
+     * @var string
+     */
+    private $render_token = '';
 
     /**
      * @param mixed  $file   see setFile() below
@@ -128,6 +132,8 @@ class PhpEcho
 
         $this->vars = $vars;
         self::addPathToHelperFile(__DIR__.DIRECTORY_SEPARATOR.'stdHelpers.php');
+
+        $this->render_token = self::token();
     }
 
     /**
@@ -274,6 +280,24 @@ class PhpEcho
     public function hasChildren(): bool
     {
         return $this->has_children;
+    }
+
+    /**
+     * Create a new instance of PhpEcho using the current directory template as root for the file to include
+     *
+     * @param string $file
+     * @param array  $vars
+     * @param string $id
+     * @return PhpEcho      Return the new instance
+     */
+    public function addChild($file = '', array $vars = [], string $id = ''): PhpEcho
+    {
+        $parts = is_string($file) ? explode(' ', $file) : $file;
+        array_unshift($parts, $this->templateDirectory());
+        $block = new PhpEcho($parts, $vars, $id);
+        $block->parent      = $this;
+        $this->has_children = true;
+        return $block;
     }
 
     /**

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -165,7 +165,7 @@ class PhpEcho
     {
         if (isset($this->vars[$offset])) {
             $v = $this->vars[$offset];
-            if (is_object($v)) {
+            if (is_object($v) || is_bool($v) || is_int($v) || is_float($v)) {
                 return $v;
             } elseif (is_array($v) || $this('$is_scalar', $v)) {
                 return $this('$hsc', $v);

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -312,17 +312,18 @@ class PhpEcho
     public function head(bool $escape): string
     {
         // generate a token that will be replaced after rendering the whole HTML
-        $this->head_token  = self::token();
+        $this->head_token  = self::token(26);
         $this->head_escape = $escape;
         return $this->head_token;
     }
 
     /**
+     * @param int $length
      * @return string
      */
-    private static function token(): string
+    private static function token(int $length = 12): string
     {
-        return str_shuffle(self::$ALPHANUM).mt_rand(100000000, 999999999);
+        return substr(str_shuffle(self::$ALPHANUM.mt_rand(100000000, 999999999)), 0, $length);
     }
 
     //region MAGIC METHODS

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -86,7 +86,11 @@ class PhpEcho
      * Indicates if the current instance contains in its vars other PhpEcho instance(s)
      * @var bool
      */
-    private $has_leafs = false;
+    private $has_children = false;
+    /**
+     * @var PhpEcho
+     */
+    private $parent;
 
     /**
      * @param mixed  $file   see setFile() below
@@ -179,7 +183,8 @@ class PhpEcho
     {
         $this->vars[$offset] = $value;
         if ($value instanceof PhpEcho) {
-            $this->has_leafs = true;
+            $this->has_children = true;
+            $value->parent   = $this;
         }
     }
 
@@ -248,9 +253,17 @@ class PhpEcho
      * Indicates if the current instance contains in its vars other PhpEcho instance(s)
      * @return bool
      */
-    public function hasLeafs(): bool
+    public function hasChildren(): bool
     {
-        return $this->has_leafs;
+        return $this->has_children;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasParent(): bool
+    {
+        return ($this->parent instanceof PhpEcho);
     }
 
     //region HTML HEAD ZONE
@@ -326,7 +339,7 @@ class PhpEcho
                     if ($v instanceof PhpEcho) {
                         $v->render(); // force the block to render
                         array_push($data, ...$v->head()->get());
-                        if ($v->hasLeafs()) {
+                        if ($v->hasChildren()) {
                             $v->head()->compile($data);
                         }
                     }

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -151,6 +151,7 @@ class PhpEcho
         $this->id = chr(mt_rand(97, 122)).bin2hex(random_bytes(4));
     }
 
+    //region ARRAY ACCESS
     /**
      * Interface ArrayAccess
      * @param mixed $offset
@@ -208,6 +209,7 @@ class PhpEcho
     {
         unset($this->vars[$offset]);
     }
+    //endregion
 
     /**
      * Define the filepath to the external view file to include
@@ -323,6 +325,7 @@ class PhpEcho
         return str_shuffle(self::$ALPHANUM).mt_rand(100000000, 999999999);
     }
 
+    //region MAGIC METHODS
     /**
      * This function call a helper defined elsewhere or dynamically
      * Auto-escape if necessary
@@ -387,6 +390,7 @@ class PhpEcho
             return $this->code;
         }
     }
+    //endregion
 
     /**
      * Manually render the block

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -54,7 +54,6 @@ if ( ! defined('HELPER_RETURN_ESCAPED_DATA')) {
  * @method string style(array $attributes)  [href => url | code => plain css definition, attribute => value]
  * @method string script(array $attributes) [src => url | code => plain javascript, attribute => value]
  * @method mixed  keyUp($keys, bool $strict_match)
- * @method mixed  keyDown($keys)
  * @method mixed  param($keys)
  */
 class PhpEcho

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ $page = new PhpEcho('Layout.php', [
     'title' => 'My first use case of PhpEcho',
     'meta'  => ['<meta name="keywords" content="PhpEcho, PHP template engine, easy to learn and use" />'],
     'body'  => new PhpEcho('LoginForm.php', [
-        'login' => 'rawsrc',
+        'login'      => 'rawsrc',
         'url_submit' => 'any/path/for/connection'
     ])
 ]);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **PhpEcho**
 
-`2020-04-14` `PHP 7+` `v.2.2.0`
+`2020-04-17` `PHP 7+` `v.2.3.0`
 
 ## **A PHP template engine : One class to rule them all**
 
@@ -25,10 +25,9 @@ The class will manage :
 * let you access to the global HTML `<head></head>` from any child block
 * let your IDE to list all your helpers natively just using PHPDoc syntax (see the PHPDoc of the class)
 
-**NEW FEATURE IN PhpEcho v.2.2.0:**<br>
-1. You have now access to the global `<head></head>` from any PhpEcho child block
-2. New helpers rendering HTML tags in a secure way
-3. Use a relative path from the current instance to target any child PhpEcho file 
+**NEW FEATURE IN PhpEcho v.2.3.0:**<br>
+1. Preserve the type of value using array notation and escaping only when necessary
+2. The way to access to the `<head></head>` is updated : the `head()->add()` is replaced by `addHead()` and `head()->render()` by `head()`
 
 **What you must know to use it**
 1. Using array access notation or function notation will always return escaped values
@@ -44,14 +43,13 @@ $x = $block['foo'];   // $x = 'abc &quot; &lt; &gt;'
 
 // escape on demand using a helper
 $y = $block('$hsc', 'any value to escape'); // or
-$y = $block->hsc('any value to escape');    // since PhpEcho 2.1.0
+$y = $block->hsc('any value to escape');    
 
 // extract the raw value on demand using a helper
 $z = $block('$raw', 'foo'); // $z = 'abc " < >' or
-$z = $block->raw('foo');    // $z = 'abc " < >' since PhpEcho 2.1.0
+$z = $block->raw('foo');    // $z = 'abc " < >' 
 
-// since PhpEcho 2.2.1
-// if you store an object you retrieve your object (even if the class implements __toString())
+// the type of value is preserved, are escaped all strings and objects having __toString()
 $block['bar'] = new stdClass();
 $bar = $block['bar'];
 ```
@@ -82,7 +80,7 @@ As everything is escaped by default in PhpEcho, we can consider that the word "c
 this is why, with the helper definition, you have the flag `HELPER_RETURN_ESCAPED_DATA`.<br>
 To call this helper inside your code (2 ways) : <br>
 * `$this('$checked', 'your value', 'ref value');`
-* `$this->checked('your value', 'ref value');    // since PhpEcho 2.1.0`
+* `$this->checked('your value', 'ref value');`
  
 Now, have a look at the helper that return the raw value from the stored key-value pair `$raw`:
 ```php
@@ -91,18 +89,21 @@ $raw = function(string $key) {
 };
 $helpers['$raw'] = [$raw, HELPER_RETURN_ESCAPED_DATA, HELPER_BOUND_TO_CLASS_INSTANCE];
 ```
-As this helper extract data from the stored key-value pairs defined in each instance of PhpEcho, it needs an access to the caller's execution context (instance of PhpEcho)
+As this helper extract data from the stored key-value pairs defined in each instance of PhpEcho, it needs an access to the caller's execution context
 that's why the helper definition has the flag `HELPER_BOUND_TO_CLASS_INSTANCE`.<br>
 And as we want to get the value unescaped, we must tell the engine that the return value by the closure is already escaped.
-We know that is not but this is goal of that helper.<br>
-To call this helper inside your code (2 ways) : <br>
+We know that is not but this is goal of that helper.<br>    
 * `$this('$raw', 'key');`
-* `$this->raw('key');    // since PhpEcho 2.1.0`
+* `$this->raw('key');`
 
 To define a helper, there're 3 ways:
 * `$helpers["$helper's name"] = $helper_closure`
 * `$helpers["$helper's name"] = [$helper_closure, HELPER_RETURN_ESCAPED_DATA]`
 * `$helpers["$helper's name"] = [$helper_closure, HELPER_RETURN_ESCAPED_DATA, HELPER_BOUND_TO_CLASS_INSTANCE]`
+
+When you write a new helper that will be bound to a class instance and needs to use another bound helper,
+you must use this syntax `$existing_helper = $this->bound_helpers['$existing_helper_name'];` inside your code. 
+Please have a look at the `$root_key` helper (how is created a link to another bound helper: `$root`).
 
 
 ## **How to**
@@ -110,7 +111,11 @@ Here's a very simple example of login form:
 
 1. First, we create a view file called `Layout.php`
 Note the expected values for keys inside `$this[]` or `$this()`.<br>
-Do not forget that all values returned by the array notation (`$this[]`) are safe in HTML context
+Do not forget that all values returned by the array notation (`$this[]`) are safe in HTML context.<br>
+In the layout below, some values are expected:
+* an array of `<meta>` strings
+* a title (string)
+* a PhpEcho block in charge of rendering the body part of the page 
 ```php
 <?php /** @var PhpEcho $this */ ?>
 <!DOCTYPE html>
@@ -121,16 +126,18 @@ Do not forget that all values returned by the array notation (`$this[]`) are saf
     <title><?= $this['title'] ?></title>
 </head>
 <body>
-<?= $this('$raw', 'body') ?>
+<?= $this['body'] ?>
 </body>
 </html>
 ```
-To get a handy help from your IDE, you can also write the code above (since PhpEcho 2.1.0) like this: `<?= $this->raw('body') ?>`<br> 
+As every PhpEcho instances are returned as it and transformed to a string when it's necessary, you can call it directly in your HTML code (as above).
+To get a handy help from your IDE, you can also write the code above like this: `<?= $this->raw('meta') ?>`<br> 
 To get the IDE autocompletion, just add as the first line of your view file `<?php /** @var PhpEcho $this */ ?>` to tell the IDE the 
 right type for `$this`.<br> 
 Note also the different ways of extracting the data from `$this` (array notation vs function notation (helpers))
 
 Then, we prepare the body of the page `LoginForm.php` :
+`$this['url_submit']` and `$this['login']` are automatically escaped 
 ```php
 <p>Please login : </p>
 <form method=post action="<?= $this['url_submit'] ?>">
@@ -160,6 +167,26 @@ $page = new PhpEcho('Layout.php', [
 
 echo $page;
 ```
+You can also use another strategy: injecting the child block directly using the parent directory as a root:
+```php
+<?php /** @var PhpEcho $this */ ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <?= implode('', $this->raw('meta') ?? []) ?>
+    <title><?= $this['title'] ?></title>
+</head>
+<body>
+<?= $this->addChild('LoginForm.php', [
+     'login'      => 'rawsrc',
+     'url_submit' => 'any/path/for/connection'
+ ]) ?>
+</body>
+</html>
+```
+This approach will let you to pilot easily the rendering without a too complex architecture from the start.
+
 
 ## **Use HEREDOC instead of file inclusion**
 
@@ -293,8 +320,53 @@ It is also possible to do like this:
 <input <?= $this->attributes(['type' => 'text', 'name' => 'name', 'required', 'value' => ' < > " <script></script>']) ?>>
 ```
 As you see, there're tons of methods to get the expected result.
-It's highly recommended creating and using your own helpers and ask to get them included by default in the package for the next release. 
+It's highly recommended creating and using your own helpers and ask to get them included by default in the package for 
+the next release. 
 
+There's 3 new helpers:
+
+**Accessing the root**
+
+You can access to the top level of the tree of blocks using the helper `$root` or `$this->root()`. This helper return 
+the top level instance of a PhpEcho class.
+
+**Global parameter**
+
+The first is `$root_key` with the corresponding method : `param()`. It gives you an access from every child block to the 
+very first PhpBlock (the root) of your whole template.
+Now, you can define some global parameters and interact with them from any child block.<br>
+
+To understand clearly, for example you define once a parameter for the whole template : `$page['document.isPopup'] = true`, 
+then in any child block you can read this parameter as simply as `$this->param('document.isPopup')`.<br>
+
+It also possible to use a multidimensional array: `$page['a']['b']['c'] = true` and in the child block: `$this->param('a b c')`.
+Please note: I consider that never a key should contain a space. This is the reason why `'a b c'` becomes an array of keys.    
+If you have a space in you key, use directly an array.
+
+**Climbing the tree of blocks**
+
+The second is `$key_up` with the corresponding method `keyUp()`. 
+From a given list of keys (string or array, string: the delimiter for each key is space), the engine will start to climb the tree 
+of blocks while the key is found. And will return the value corresponding to the last key or null if not found.<br>
+With the parameter `$strict_match`, it possible to tell the engine to continue to climb if the current key is still not found.
+```php
+// imagine you have a tree of PhpEcho blocks corresponding to a part of the DOM
+$block1['abc'] = 'rawsrc';
+$block1['form1'] = $block2;
+    $block2['def'] = 'github';
+    $block2['tab'] = $block3; 
+        $block3['tab_footer'] = $block4; 
+
+// now from the $block4 you want to read the value for the key 'abc'
+// with $strict_match === true you must define the whole path to the block
+$x = $this->keyUp('tab abc', true); 
+// this is equivalent
+$x = $this->keyUp('def abc', true);
+
+// with $strict_match === false you know there's a parent block having the key
+// but you don't know the path to get it out
+$x = $this->keyUp('abc', false);
+```
   
 ## **Accessing the top `<head></head>` from any child PhpEcho block**
 
@@ -302,16 +374,16 @@ When you code the view part of a website, you will create plenty of small blocks
 As everybody knows, the best design is to keep your blocks in the most independent way from the others. Sometimes you will need to add some dependencies
 directly in the header of the page. This is also possible using PhpEcho as your main template engine.
 
-In any instance of PhpEcho, you have a method named `head()` which is designed for this purpose.
+In any instance of PhpEcho, you have a method named `addhead()` which is designed for this purpose.
 
 Now, imagine you're in the depths of the DOM, you're coding a block and need to tell the header to declare a link to your library.
 In the current block, you will do:
 ```php
-<?php $this->head()->add('<script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous">') ?>
+<?php $this->addHead('<script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous">') ?>
 ```  
 or using a helper `script` that will secure all your values
 ```php
-<?php $this->head()->add('script', [
+<?php $this->addHead('script', [
     'src'         => "https://code.jquery.com/jquery-3.4.1.min.js", 
     'integrity'   => "sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=", 
     'crossorigin' => "anonymous"]) ?>
@@ -319,7 +391,7 @@ or using a helper `script` that will secure all your values
 Now in the block that renders the `<head></head>`, you just have to code:
 ```php
 <head>
-    <?= $this->head()->render(); ?>
+    <?= $this->head(); ?>
 </head>
 ``` 
 The engine will compile the `<head></head>` parameters from all the child blocks to render the header.
@@ -329,10 +401,11 @@ The concept of child block is easy to understand: when you define a PhpEcho clas
 $page = new PhpEcho('Layout.php');
 $page['body'] = new PhpEcho('Body.php');    // here's the child block 
 ```
+or if you use the method `addChild()`.
 
 ## **Using a relative path to target any child PhpEcho block**
 When you create a PhpEcho instance, usually you will pass to the constructor the filepath of the view file.
-You can get directly the last template directory using `templateDirectory()` and use it as a root to build other dynamics paths 
+You can get directly the last template directory using `templateDirectory()` and use it as a root to build other dynamics paths. 
 
 Enjoy!
 

--- a/stdHelpers.php
+++ b/stdHelpers.php
@@ -337,7 +337,7 @@ $helpers['keyUp']   = $helpers['$key_up'];
  * A string will be split in parts using the space for delimiter
  * If one of the keys contains a space, use an array of keys instead
  *
- * @param string|array $key
+ * @param string|array $keys
  * @return mixed|null                   null if not found
  */
 $key_down = function($keys) use ($escape, $hsc) {

--- a/stdHelpers.php
+++ b/stdHelpers.php
@@ -376,7 +376,6 @@ $root_key = function($keys) use ($to_escape, $hsc) {
     }
 };
 $helpers['$root_key'] = [$root_key, HELPER_BOUND_TO_CLASS_INSTANCE, HELPER_RETURN_ESCAPED_DATA];
-$helpers['rootKey']   = $helpers['$root_key'];  // alias for method call
 $helpers['param']     = $helpers['$root_key'];  // alias for method call
 
 

--- a/stdHelpers.php
+++ b/stdHelpers.php
@@ -33,7 +33,7 @@ $helpers['isScalar']   = $helpers['$is_scalar']; // alias for method call
 
 
 /**
- * Tell if the value in parameter should be escaped or not
+ * Check if the value in parameter should be escaped or not
  *
  * @param $p
  * @return bool
@@ -52,7 +52,6 @@ $to_escape = function($p) use ($is_scalar): bool  {
     }
 };
 $helpers['$to_escape'] = [$to_escape, HELPER_RETURN_ESCAPED_DATA];
-
 
 /**
  * Return an array of escaped values with htmlspecialchars(ENT_QUOTES, 'utf-8') for both keys and values
@@ -284,12 +283,12 @@ $helpers['$script'] = [$style, HELPER_RETURN_ESCAPED_DATA];
 
 
 /**
- * This helper will climb the tree of PhpEcho instances from the current while the key match
+ * This helper will climb the tree of PhpEcho instances from the current block while the key match
  *
  * A string will be split in parts using the space for delimiter
  * If one of the keys contains a space, use an array of keys instead
  *
- * If $strict_match === true then every key must be found in the parent block as they are listed
+ * If $strict_match === true then every key must be found in the parent blocks tree as they are listed
  * If $strict_match === false then if the current key is not found in the parent block, then the search will continue
  * until reaching the root or stop at the first match
  *
@@ -334,29 +333,38 @@ $helpers['keyUp']   = $helpers['$key_up'];
 
 
 /**
- * This helper will extract a value from a key stored in the root of the tree of PhpEcho instances
- * and go down while the key match.
- *
- * This function does not render the PhpEcho blocks. So, if you target a PhpEcho block that has not been rendered yet,
- * the key might not be available.
- *
- * A string will be split in parts using the space for delimiter
- * If one of the keys contains a space, use an array of keys instead
- *
- * @param string|array $keys
- * @return mixed|null                   null if not found
+ * @return PhpEcho
  */
-$root_key = function($keys) use ($to_escape, $hsc) {
+$root = function(): PhpEcho {
     // climbing to the root
     /** @var PhpEcho $block */
     $block = $this;
     while ($block->hasParent()) {
         $block = $block->parent;
     }
+    return $block;
+};
+$helpers['$root'] = [$root, HELPER_BOUND_TO_CLASS_INSTANCE, HELPER_RETURN_ESCAPED_DATA];
 
-    $keys = is_string($keys) ? explode(' ', $keys) : $keys;
-    $nb   = count($keys);
-    $i    = 0;
+
+/**
+ * This helper will extract a value from a key stored in the root of the tree of PhpEcho instances
+ * and go down while the key match. This function does not render the PhpRcho blocks
+ *
+ * A string will be split in parts using the space for delimiter
+ * If one of the keys contains a space, use an array of keys instead
+ *
+ * @param string|array $keys
+ * @return mixed|null          null if not found
+ */
+$root_key = function($keys) use ($to_escape, $hsc) {
+    /** @var PhpEcho $this */
+    $root  = $this->bound_helpers['$root'];
+    /** @var PhpEcho $block */
+    $block = $root();   // get the root PhpEcho block
+    $keys  = is_string($keys) ? explode(' ', $keys) : $keys;
+    $nb    = count($keys);
+    $i     = 0;
     while ($i < $nb) {
         $k = $keys[$i];
         if (isset($block[$k])) {

--- a/stdHelpers.php
+++ b/stdHelpers.php
@@ -38,7 +38,7 @@ $helpers['isScalar']   = $helpers['$is_scalar']; // alias for method call
  * @param $p
  * @return bool
  */
-$escape = function($p) use ($is_scalar): bool  {
+$to_escape = function($p) use ($is_scalar): bool  {
     if (is_string($p)) {
         return true;
     } elseif (is_bool($p) || is_int($p) || is_float($p) || ($p instanceof PhpEcho)) {
@@ -51,6 +51,8 @@ $escape = function($p) use ($is_scalar): bool  {
         return true;
     }
 };
+$helpers['$to_escape'] = [$to_escape, HELPER_RETURN_ESCAPED_DATA];
+
 
 /**
  * Return an array of escaped values with htmlspecialchars(ENT_QUOTES, 'utf-8') for both keys and values
@@ -64,11 +66,11 @@ $escape = function($p) use ($is_scalar): bool  {
  * @param  array $part
  * @return array
  */
-$hsc_array = function(array $part) use (&$hsc_array, $escape): array {
+$hsc_array = function(array $part) use (&$hsc_array, $to_escape): array {
     $data = [];
     foreach ($part as $k => $v) {
         $sk = htmlspecialchars((string)$k, ENT_QUOTES, 'utf-8');
-        if ($escape($v)) {
+        if ($to_escape($v)) {
             if (is_array($v)) {
                 $data[$sk] = $hsc_array($v);
             } else {
@@ -295,7 +297,7 @@ $helpers['$script'] = [$style, HELPER_RETURN_ESCAPED_DATA];
  * @param bool         $strict_match
  * @return mixed|null                   null if not found
  */
-$key_up = function($keys, bool $strict_match = true) use ($escape, $hsc) {
+$key_up = function($keys, bool $strict_match = true) use ($to_escape, $hsc) {
     /** @var PhpEcho $this */
     if ( ! $this->hasParent()) {
         return null;
@@ -309,7 +311,7 @@ $key_up = function($keys, bool $strict_match = true) use ($escape, $hsc) {
         $k = $keys[$i];
         if (isset($block[$k])) {
             if ($i + 1 >= $nb) {
-                if ($escape($block[$k])) {
+                if ($to_escape($block[$k])) {
                     return $hsc($block[$k]);
                 } else {
                     return $block[$k];
@@ -340,7 +342,7 @@ $helpers['keyUp']   = $helpers['$key_up'];
  * @param string|array $keys
  * @return mixed|null                   null if not found
  */
-$key_down = function($keys) use ($escape, $hsc) {
+$key_down = function($keys) use ($to_escape, $hsc) {
     // climbing to the root
     /** @var PhpEcho $block */
     $block = $this;
@@ -355,7 +357,7 @@ $key_down = function($keys) use ($escape, $hsc) {
         $k = $keys[$i];
         if (isset($block[$k])) {
             if ($i + 1 >= $nb) {
-                if ($escape($block[$k])) {
+                if ($to_escape($block[$k])) {
                     return $hsc($block[$k]);
                 } else {
                     return $block[$k];

--- a/stdHelpers.php
+++ b/stdHelpers.php
@@ -291,7 +291,7 @@ $helpers['$script'] = [$style, HELPER_RETURN_ESCAPED_DATA];
  * If $strict_match === false then if the current key is not found in the parent block, then the search will continue
  * until reaching the root or stop at the first match
  *
- * @param string|array $key
+ * @param string|array $keys
  * @param bool         $strict_match
  * @return mixed|null                   null if not found
  */

--- a/stdHelpers.php
+++ b/stdHelpers.php
@@ -334,7 +334,11 @@ $helpers['keyUp']   = $helpers['$key_up'];
 
 
 /**
- * This helper will start from the root of the tree of PhpEcho instances and go down while the key match
+ * This helper will extract a value from a key stored in the root of the tree of PhpEcho instances
+ * and go down while the key match.
+ *
+ * This function does not render the PhpEcho blocks. So, if you target a PhpEcho block that has not been rendered yet,
+ * the key might not be available.
  *
  * A string will be split in parts using the space for delimiter
  * If one of the keys contains a space, use an array of keys instead
@@ -342,7 +346,7 @@ $helpers['keyUp']   = $helpers['$key_up'];
  * @param string|array $keys
  * @return mixed|null                   null if not found
  */
-$key_down = function($keys) use ($to_escape, $hsc) {
+$root_key = function($keys) use ($to_escape, $hsc) {
     // climbing to the root
     /** @var PhpEcho $block */
     $block = $this;
@@ -371,9 +375,9 @@ $key_down = function($keys) use ($to_escape, $hsc) {
         }
     }
 };
-$helpers['$key_down'] = [$key_down, HELPER_BOUND_TO_CLASS_INSTANCE, HELPER_RETURN_ESCAPED_DATA];
-$helpers['keyDown']   = $helpers['$key_down'];  // alias for method call
-$helpers['param']     = $helpers['$key_down'];  // alias for method call
+$helpers['$root_key'] = [$root_key, HELPER_BOUND_TO_CLASS_INSTANCE, HELPER_RETURN_ESCAPED_DATA];
+$helpers['rootKey']   = $helpers['$root_key'];  // alias for method call
+$helpers['param']     = $helpers['$root_key'];  // alias for method call
 
 
 // return the array of helpers to PhpEcho

--- a/stdHelpers.php
+++ b/stdHelpers.php
@@ -34,8 +34,9 @@ $helpers['isScalar']   = $helpers['$is_scalar']; // alias for method call
 
 /**
  * Return an array of escaped values with htmlspecialchars(ENT_QUOTES, 'utf-8') for both keys and values
- * Works for scalar and array type and transform any object having __toString() function implemented to a escaped string
- * Otherwise, keep the object as it
+ *
+ * Preserved types : true bool, true int, true float, PhpEcho instance, object without __toString()
+ * Otherwise, the value is cast to a string and escaped
  *
  * This is a standalone helper that is not directly accessible
  * Use instead the common helper '$hsc' which is compatible with arrays
@@ -47,8 +48,12 @@ $hsc_array = function(array $part) use (&$hsc_array, $is_scalar): array {
     $data = [];
     foreach ($part as $k => $v) {
         $sk = htmlspecialchars((string)$k, ENT_QUOTES, 'utf-8');
-        if (is_array($v)) {
+        if (is_string($v)) {
+            $data[$sk] = htmlspecialchars((string)$v, ENT_QUOTES, 'utf-8');
+        } elseif (is_array($v)) {
             $data[$sk] = $hsc_array($v);
+        } elseif (is_bool($v) || is_int($v) || is_float($v) || ($v instanceof PhpEcho)) {
+            $data[$sk] = $v;
         } elseif ($is_scalar($v)) {
             $data[$sk] = htmlspecialchars((string)$v, ENT_QUOTES, 'utf-8');
         } else {
@@ -62,7 +67,11 @@ $hsc_array = function(array $part) use (&$hsc_array, $is_scalar): array {
 /**
  * This is a standalone helper
  *
- * @param  $p
+ * When $p is an array, some types are preserved:
+ * - true bool, true int, true float, PhpEcho instance, object without __toString()
+ * Otherwise, the value is cast to a string and escaped
+ *
+ * @param  mixed $p
  * @return mixed
  */
 $hsc = function($p) use ($hsc_array, $is_scalar) {
@@ -252,5 +261,15 @@ $script = function(array $p) use ($tag): string {
 $helpers['$script'] = [$style, HELPER_RETURN_ESCAPED_DATA];
 
 
+/**
+ * This helper will climb the tree of PhpEcho
+ *
+ * @param $key
+ */
+$seek_asc = function($key) {
+
+};
+$helpers['$seek_asc'] = [$seek_asc, HELPER_BOUND_TO_CLASS_INSTANCE, HELPER_RETURN_ESCAPED_DATA];
+$helpers['seekAsc']   = $helpers['$seek_asc'];
 // return the array of helpers to PhpEcho
 return $helpers;


### PR DESCRIPTION
1. Preserve the type of value using array notation and escaping only when necessary
2. The way to access to the `<head></head>` is updated : the `head()->add()` is replaced by `addHead()` and `head()->render()` by `head()`