### PR TITLE
Release 2.3.1

### DIFF
--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -43,7 +43,7 @@ if ( ! defined('HELPER_RETURN_ESCAPED_DATA')) {
  * @method mixed   raw(string $key)                 Return the raw value from a PhpEcho block
  * @method bool    isScalar($p)
  * @method mixed   keyUp($keys, bool $strict_match) Climb the tree of PhpEcho instances while keys match
- * @method mixed   param($keys)                     Extract a value from the root PhpEcho instance of the tree
+ * @method mixed   rootKey($keys)                   Extract the value from the top level PhpEcho block (the root)
  * @method PhpEcho root()                           Return the root PhpEcho instance of the tree
  *
  * HTML HELPERS
@@ -166,12 +166,18 @@ class PhpEcho
     }
 
     /**
+     * The param is never escaped
+     *
      * @param string $name
-     * @return |null
+     * @return mixed|null
      */
     public function param(string $name)
     {
-        return $this->params[$name] ?? null;
+        if ($this->hasParam($name)) {
+            return $this->params[$name];
+        }
+        // seek up the tree of blocks for the param value
+        return $this('$seek_param', $name);
     }
 
     /**
@@ -180,7 +186,7 @@ class PhpEcho
      */
     public function hasParam(string $name): bool
     {
-        return in_array($name, $this->params);
+        return in_array($name, array_keys($this->params));
     }
 
     /**

--- a/PhpEcho.php
+++ b/PhpEcho.php
@@ -77,6 +77,10 @@ class PhpEcho
     /**
      * @var array
      */
+    private $params = [];
+    /**
+     * @var array
+     */
     private $head = [];
     /**
      * @var string
@@ -150,6 +154,33 @@ class PhpEcho
     public function id(): string
     {
         return $this->id;
+    }
+
+    /**
+     * @param string $name
+     * @param        $value
+     */
+    public function setParam(string $name, $value)
+    {
+        $this->params[$name] = $value;
+    }
+
+    /**
+     * @param string $name
+     * @return |null
+     */
+    public function param(string $name)
+    {
+        return $this->params[$name] ?? null;
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function hasParam(string $name): bool
+    {
+        return in_array($name, $this->params);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ The class will manage :
 * let you access to the global HTML `<head></head>` from any child block
 * let your IDE to list all your helpers natively just using PHPDoc syntax (see the PHPDoc of the class)
 
-**NEW FEATURES IN PhpEcho v.2.3.0:**<br>
-1. Preserve the type of value using array notation and escaping only when necessary
-2. The way to access to the `<head></head>` is updated : the `head()->add()` is replaced by `addHead()` and `head()->render()` by `head()`
+**NEW FEATURES IN PhpEcho v.2.3.1:**<br>
+1. Each PhpEcho instance can now define their own parameters. 
+2. Parameters remain raw value and are never escaped. 
+2. The engine will always seek for a parameter value from the current block to the root. 
 
 **What you must know to use it**
 1. Using array access notation or function notation will always return escaped values

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ html
 
 ## **Parameters**
 
-Since PhpEcho 2.3.1, each instance of PhpEcho can define their own parameters.<br>
+Since PhpEcho 2.3.1, each instance of PhpEcho can now have their own parameters.<br>
 Please note that the parameters are never escaped. 
 ```php
 // In any block
@@ -309,11 +309,11 @@ Please note that the parameters are never escaped.
 $this->setParam('document.isPopup', true);
 
 // get the parameter
-$is_popup = $this->param('document.isPopup');
+$is_popup = $this->param('document.isPopup'); // true
 ```
 There's an interesting point to keep in mind, when the parameter is not defined in the current instance
 then the engine will automatically seek for it through the parent PhpEcho instances. It will climb the leaves to the root 
-and stop if the parameter is found or return null when not found.
+and stop if the parameter is found or return null.
 
 
 ## **Let's play with helpers**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **PhpEcho**
 
-`2020-04-17` `PHP 7+` `v.2.3.0`
+`2020-04-18` `PHP 7+` `v.2.3.1`
 
 ## **A PHP template engine : One class to rule them all**
 
@@ -298,6 +298,23 @@ html
     );
 ```
 
+## **Parameters**
+
+Since PhpEcho 2.3.1, each instance of PhpEcho can define their own parameters.<br>
+Please note that the parameters are never escaped. 
+```php
+// In any block
+// set a parameter
+$this->setParam('document.isPopup', true);
+
+// get the parameter
+$is_popup = $this->param('document.isPopup');
+```
+There's an interesting point to keep in mind, when the parameter is not defined in the current instance
+then the engine will automatically seek for it through the parent PhpEcho instances. It will climb the leaves to the root 
+and stop if the parameter is found or return null when not found.
+
+
 ## **Let's play with helpers**
 As mentioned above, there's some new helpers that have been added to the standard helpers library `stdHelpers.php`.
 These helpers will help you to render any HTML code and/or interact with any PhpEcho instance.
@@ -323,21 +340,20 @@ As you see, there're tons of methods to get the expected result.
 It's highly recommended creating and using your own helpers and ask to get them included by default in the package for 
 the next release. 
 
-There's 3 new helpers:
+
+New helpers:
 
 **Accessing the root**
 
-You can access to the top level of the tree of blocks using the helper `$root` or `$this->root()`. This helper return 
-the top level instance of a PhpEcho class.
+The root class is a special object that is available for any child PhpEcho instance.
 
-**Global parameter**
+You have a direct access to it using the helper `$root` or `$this->root()`. This helper return the top level instance of a PhpEcho class.
 
-The first is `$root_key` with the corresponding method : `param()`. It gives you an access from every child block to the 
-very first PhpBlock (the root) of your whole template.
-Now, you can define some global parameters and interact with them from any child block.<br>
+**Accessing a value stored in the root**
 
-To understand clearly, for example you define once a parameter for the whole template : `$page['document.isPopup'] = true`, 
-then in any child block you can read this parameter as simply as `$this->param('document.isPopup')`.<br>
+As any other PhpEcho instance, you can store inside any value and retrieve it from any child block using the helper `$root_key` 
+with the corresponding method : `rootKey()`. Now, you can define some global values and interact with them from any child block.<br>
+These values behave like any standard value and are of course escaped when necessary.
 
 It also possible to use a multidimensional array: `$page['a']['b']['c'] = true` and in the child block: `$this->param('a b c')`.
 Please note: I consider that never a key should contain a space. This is the reason why `'a b c'` becomes an array of keys.    
@@ -345,7 +361,7 @@ If you have a space in you key, use directly an array.
 
 **Climbing the tree of blocks**
 
-The second is `$key_up` with the corresponding method `keyUp()`. 
+The last is `$key_up` with the corresponding method `keyUp()`. 
 From a given list of keys (string or array, string: the delimiter for each key is space), the engine will start to climb the tree 
 of blocks while the key is found. And will return the value corresponding to the last key or null if not found.<br>
 With the parameter `$strict_match`, it possible to tell the engine to continue to climb if the current key is still not found.

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ the next release.
 
 New helpers:
 
-**Accessing the root**
+**Access the root**
 
 The root class is a special object that is available for any child PhpEcho instance.
 

--- a/stdHelpers.php
+++ b/stdHelpers.php
@@ -384,8 +384,29 @@ $root_key = function($keys) use ($to_escape, $hsc) {
     }
 };
 $helpers['$root_key'] = [$root_key, HELPER_BOUND_TO_CLASS_INSTANCE, HELPER_RETURN_ESCAPED_DATA];
-$helpers['param']     = $helpers['$root_key'];  // alias for method call
+$helpers['rootKey']   = $helpers['$root_key'];  // alias for method call
 
+
+/**
+ * Seek the parameter from the current block to the root
+ *
+ * @param string $name
+ * @return null
+ */
+$seek_param = function(string $name) {
+    /** @var PhpEcho $block */
+    $block = $this;
+    while (true) {
+        if ($block->hasParam($name)) {
+            return $block->params[$name];
+        } elseif ($block->hasParent()) {
+            $block = $block->parent;
+        } else {
+            return null;
+        }
+    }
+};
+$helpers['$seek_param'] = [$seek_param, HELPER_BOUND_TO_CLASS_INSTANCE, HELPER_RETURN_ESCAPED_DATA];
 
 // return the array of helpers to PhpEcho
 return $helpers;


### PR DESCRIPTION
**NEW FEATURES IN PhpEcho v.2.3.1:**<br>
1. Each PhpEcho instance can now define their own parameters. 
2. Parameters remain raw value and are never escaped. 
2. The engine will always seek for a parameter value from the current block to the root. 

**Changelog:**
The `param()` helper becomes a method of the class PhpEcho
The old `param()` helper is renamed to `rootKey()`
New helper : `$seek_param` accessible using the new method `param()`